### PR TITLE
Rename wait helper to getWait

### DIFF
--- a/playground-e2e/src/main/java/framework/waits/Waits.java
+++ b/playground-e2e/src/main/java/framework/waits/Waits.java
@@ -17,36 +17,36 @@ public class Waits {
         this.driver = driver;
     }
 
-    private WebDriverWait wait() {
+    private WebDriverWait getWait() {
         return new WebDriverWait(driver, timeout);
     }
 
     public WebElement visible(By locator) {
-        return wait().until(ExpectedConditions.visibilityOfElementLocated(locator));
+        return getWait().until(ExpectedConditions.visibilityOfElementLocated(locator));
     }
 
     public WebElement clickable(By locator) {
-        return wait().until(ExpectedConditions.elementToBeClickable(locator));
+        return getWait().until(ExpectedConditions.elementToBeClickable(locator));
     }
 
     public WebElement present(By locator) {
-        return wait().until(ExpectedConditions.presenceOfElementLocated(locator));
+        return getWait().until(ExpectedConditions.presenceOfElementLocated(locator));
     }
 
     public boolean textToBe(By locator, String text) {
-        return wait().until(ExpectedConditions.textToBe(locator, text));
+        return getWait().until(ExpectedConditions.textToBe(locator, text));
     }
 
     public boolean attributeToBe(By locator, String attr, String value) {
-        return wait().until(ExpectedConditions.attributeToBe(locator, attr, value));
+        return getWait().until(ExpectedConditions.attributeToBe(locator, attr, value));
     }
 
     public boolean urlContains(String fragment) {
-        return wait().until(ExpectedConditions.urlContains(fragment));
+        return getWait().until(ExpectedConditions.urlContains(fragment));
     }
 
     public void ajaxDone() {
-        wait().until(d -> {
+        getWait().until(d -> {
             Object res = ((JavascriptExecutor) d).executeScript("return window.jQuery ? jQuery.active == 0 : true");
             return Boolean.TRUE.equals(res);
         });


### PR DESCRIPTION
## Summary
- rename Waits.wait() to getWait()
- update all internal calls to use getWait()

## Testing
- `mvn clean test -DbaseUrl=http://localhost:3000 -Dbrowser=chrome -Dheadless=true` *(fails: could not resolve maven-clean-plugin due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68a4c8229c548320aa29fe3cec24081d